### PR TITLE
Raise `NameError` when there is no `current_user`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-### Arcane **1.1.1** [head][current] - 2013-07-17
+### Arcane **1.2.0** [head] - 2015-03-18
+* **[breaking change]** If `current_user` is not
+  specified `current_params_user` will raise a
+  `NameError`.
+
+### Arcane **1.1.1** [current] - 2013-07-17
 * **[bugfix]** Handle nil paramaters params as
   @caulfield suggested in pull request #7. Thank you.
   This doesn't break any functionality other than expecting

--- a/lib/arcane.rb
+++ b/lib/arcane.rb
@@ -32,7 +32,7 @@ module Arcane
   end
 
   def current_params_user
-    respond_to?(:current_user) ? current_user : nil
+    current_user
   end
 
   def params

--- a/spec/arcane_spec.rb
+++ b/spec/arcane_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+class MockController
+  attr_accessor :request, :user
+  def initialize(request, user)
+    @request, @user = request, user
+  end
+end
+
+class MockNoUserController
+  attr_accessor :request
+  def initialize(request)
+    @request = request
+  end
+end
+
 describe Arcane do
 
   let(:user)       { double(name: :user) }
@@ -29,6 +43,15 @@ describe Arcane do
     it 'handles nil' do
       controller.params = nil
       controller.instance_variable_get(:@_params).should be_nil
+    end
+  end
+
+  describe "#current_params_user" do
+    context "when there is no current user" do
+      let(:controller) { MockNoUserController.new(request).tap { |c| c.extend(Arcane) } }
+      it "should raise a no method error" do
+        expect { controller.current_params_user }.to raise_exception NameError
+      end
     end
   end
 


### PR DESCRIPTION
Potentially solves #12
